### PR TITLE
Refactor: avoid generics

### DIFF
--- a/spec/cr_manga_downloadr/concurrency_spec.cr
+++ b/spec/cr_manga_downloadr/concurrency_spec.cr
@@ -3,9 +3,9 @@ require "../spec_helper"
 describe CrMangaDownloadr::Concurrency do
   it "should process a large queue of jobs in batches, concurrently and signal through a channel" do
     config = CrMangaDownloadr::Config.new("foo.com", "/", "/tmp", 10, "", 10)
-    reactor = CrMangaDownloadr::Concurrency(Int32, Int32, CrMangaDownloadr::Pages).new(config, false)
-    collection = ( 1..10_000 ).to_a
-    results = reactor.fetch(collection) do |item, _|
+    reactor = CrMangaDownloadr::Concurrency.new(config, false)
+    collection = (1..10_000).to_a
+    results = reactor.fetch(collection, CrMangaDownloadr::Pages) do |item, _|
       [item]
     end
     results.size.should eq(10_000)

--- a/src/cr_manga_downloadr/chapters.cr
+++ b/src/cr_manga_downloadr/chapters.cr
@@ -2,16 +2,15 @@ require "./downloadr_client"
 require "xml"
 
 module CrMangaDownloadr
-  class Chapters < DownloadrClient(Array(String))
-    def initialize(@domain, @root_uri : String)
-      super(@domain)
+  class Chapters < DownloadrClient
+    def initialize(domain, @root_uri : String)
+      super(domain)
     end
 
     def fetch
-      get @root_uri do |html|
-        nodes = html.xpath_nodes("//table[contains(@id, 'listing')]//td//a/@href")
-        nodes.map { |node| node.text as String }
-      end
+      html = get(@root_uri)
+      nodes = html.xpath_nodes("//table[contains(@id, 'listing')]//td//a/@href")
+      nodes.map { |node| node.text.as(String) }
     end
   end
 end

--- a/src/cr_manga_downloadr/downloadr_client.cr
+++ b/src/cr_manga_downloadr/downloadr_client.cr
@@ -2,8 +2,9 @@ require "http/client"
 require "xml"
 
 module CrMangaDownloadr
-  class DownloadrClient(T)
+  class DownloadrClient
     @http_client : HTTP::Client
+
     def initialize(@domain : String)
       @http_client = HTTP::Client.new(@domain).tap do |c|
         c.connect_timeout = 30.seconds
@@ -16,25 +17,23 @@ module CrMangaDownloadr
       @http_client.try &.close
     end
 
-    def finalize
-      close
-    end
-
-    def get(uri : String, &block : XML::Node -> T)
-      response = @http_client.get(uri, headers: HTTP::Headers{ "User-Agent": CrMangaDownloadr::USER_AGENT })
-      case response.status_code
-      when 301
-        get response.headers["Location"], &block
-      when 200
-        parsed = XML.parse_html(response.body)
-        block.call(parsed)
+    def get(uri : String)
+      while true
+        begin
+          response = @http_client.get(uri, headers: HTTP::Headers{"User-Agent": CrMangaDownloadr::USER_AGENT})
+          case response.status_code
+          when 301
+            uri = response.headers["Location"]
+          when 200
+            return XML.parse_html(response.body)
+          end
+        rescue IO::Timeout
+          # TODO: naive infinite retry, it will loop infinitely if the link really doesn't exist
+          # so should have a way to control the amount of retries per link
+          puts "Sleeping over #{uri}"
+          sleep 1
+        end
       end
-    rescue IO::Timeout
-      # TODO: naive infinite retry, it will loop infinitely if the link really doesn't exist
-      # so should have a way to control the amount of retries per link
-      puts "Sleeping over #{uri}"
-      sleep 1
-      get(uri, &block)
     end
   end
 end

--- a/src/cr_manga_downloadr/image_downloader.cr
+++ b/src/cr_manga_downloadr/image_downloader.cr
@@ -1,10 +1,10 @@
 require "./downloadr_client"
 
 module CrMangaDownloadr
-  class ImageDownloader < DownloadrClient(String)
+  class ImageDownloader < DownloadrClient
     def fetch(image_src : String, filename : String)
       File.delete(filename) if File.exists?(filename)
-      response = @http_client.get(image_src, headers: HTTP::Headers{ "User-Agent": CrMangaDownloadr::USER_AGENT })
+      response = @http_client.get(image_src, headers: HTTP::Headers{"User-Agent": CrMangaDownloadr::USER_AGENT})
       case response.status_code
       when 301
         fetch(response.headers["Location"], filename)

--- a/src/cr_manga_downloadr/page_image.cr
+++ b/src/cr_manga_downloadr/page_image.cr
@@ -3,26 +3,25 @@ require "xml"
 require "uri"
 
 module CrMangaDownloadr
-  class PageImage < DownloadrClient(CrMangaDownloadr::Image)
+  class PageImage < DownloadrClient
     def fetch(page_link : String)
-      get page_link do |html|
-        images = html.xpath("//img[contains(@id, 'img')]").as(XML::NodeSet)
+      html = get(page_link)
+      images = html.xpath("//img[contains(@id, 'img')]").as(XML::NodeSet)
 
-        image_alt = images[0]["alt"]
-        image_src = images[0]["src"]
+      image_alt = images[0]["alt"]
+      image_src = images[0]["src"]
 
-        if image_alt && image_src
-          extension      = image_src.split(".").last
-          list           = image_alt.split(" ").reverse
-          title_name     = list[4..-1].join(" ")
-          chapter_number = list[3].rjust(5, '0')
-          page_number    = list[0].rjust(5, '0')
+      if image_alt && image_src
+        extension      = image_src.split(".").last
+        list           = image_alt.split(" ").reverse
+        title_name     = list[4..-1].join(" ")
+        chapter_number = list[3].rjust(5, '0')
+        page_number    = list[0].rjust(5, '0')
 
-          uri = URI.parse(image_src)
-          CrMangaDownloadr::Image.new(uri.host as String, uri.path as String, "#{title_name}-Chap-#{chapter_number}-Pg-#{page_number}.#{extension}")
-        else
-          raise Exception.new("Couldn't find proper metadata alt in the image tag")
-        end
+        uri = URI.parse(image_src)
+        CrMangaDownloadr::Image.new(uri.host.as(String), uri.path.as(String), "#{title_name}-Chap-#{chapter_number}-Pg-#{page_number}.#{extension}")
+      else
+        raise Exception.new("Couldn't find proper metadata alt in the image tag")
       end
     end
   end

--- a/src/cr_manga_downloadr/pages.cr
+++ b/src/cr_manga_downloadr/pages.cr
@@ -2,12 +2,11 @@ require "./downloadr_client"
 require "xml"
 
 module CrMangaDownloadr
-  class Pages < DownloadrClient(Array(String))
+  class Pages < DownloadrClient
     def fetch(chapter_link : String)
-      get chapter_link do |html|
-        nodes = html.xpath_nodes("//div[@id='selectpage']//select[@id='pageMenu']//option")
-        nodes.map { |node| [chapter_link, node.text as String].join("/") }
-      end
+      html = get(chapter_link)
+      nodes = html.xpath_nodes("//div[@id='selectpage']//select[@id='pageMenu']//option")
+      nodes.map { |node| "#{chapter_link}/#{node.text}" }
     end
   end
 end


### PR DESCRIPTION
Hi Akita!

I saw your blog about the manga downloader. This is an excellent project! I actually like Japanese Anime and Manga, so I'll probably use your program. One Punch Man is being recommended a lot here, so I might give it a try ;-)

I see that in your code you make heavy use of generics. This isn't bad, but I always imagine generics being used for collection classes. If it's something that doesn't look like a collection, maybe there's a simpler solution than just using generics. Generics work, but they don't exist in Ruby, and they require type annotations. If we can avoid them, code is simpler and Ruby programmers are not scared by them. The compiler is pretty smart, so we can delegate most of the job of figuring types to it. We can also pass types as argument, like in Ruby, which makes it less necessary to pass types as generic type arguments.

The refactors I did are:
1. DownloaderClient doesn't need to be generic. I guess you needed that because you wanted to recurse on the `get` method, and you couldn't. Maybe you tried `yield` first. The solution is to use a loop. In this way we also don't need a block at all, we just return the result. The HTTP::Client doesn't have follow redirect right now, there's an [issue](https://github.com/crystal-lang/crystal/issues/2721) tracking that, so in the future you might not even to write that loop at all.
2. Concurrency doesn't need to be generic. We can pass the engine class as an argument, and capture its type generically with a free variable. Check the section [free variables](http://crystal-lang.org/docs/syntax_and_semantics/type_restrictions.html) in that page, at the bottom. Like that, we can get the types we need from the arguments, without having to manually add them in our code. Let the compiler do the job for you :-)
3. I made Concurrency a struct. This is OK because it just wraps some values that don't change. Structs are nice because they don't allocate heap memory and so they don't put pressure on the GC.

In fact, we could make DownloaderClient an abstract struct and let the other types inherit from it, and also be structs. DownloaderClient is just a wrapper around an HTTP::Client, and that variable isn't reassigned. This again avoids some memory allocations. But I didn't do it because maybe it was too much for a PR :-)

I also removed a `flatten`, I don't know why it was there.

Then I made then Channel item type in Concurrency not be nilable. If there are no results we simply don't send that value over the channel. This should be a bit faster.

I didn't benchmark this, it probably just remained the same speed. There's an [issue with the DNS resolver](https://github.com/crystal-lang/crystal/issues/2660) right now, that might be the issue you are stumbling with. I don't know why it's slower than the Ruby version, I'm sure it can be improved. Maybe it's because the GC we use isn't good enough. Maybe we still need to optimize some things in the standard library or the generated code, I don't know. Another reason might be that we just use one Thread, while Ruby and Elixir can use more.

Feel free to reject this PR if the code style doesn't match yours :-)

And thank you again for writing articles about Crystal. These are very needed right now, and I like it that you are objective in them, showing that Crystal isn't always the best. That makes us want to improve it more! 😸 
